### PR TITLE
Adicionado O swagger e Redoc

### DIFF
--- a/backend/eventsync_api/api/urls.py
+++ b/backend/eventsync_api/api/urls.py
@@ -1,4 +1,6 @@
 from django.urls import path
+from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
+                                   SpectacularSwaggerView)
 from rest_framework_simplejwt import views as jwt_views
 
 from .views import auth_view as authv
@@ -16,4 +18,11 @@ urlpatterns += [
     path('register/', authv.RegisterView.as_view(), name='register'),
     path('login/', jwt_views.TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', jwt_views.TokenRefreshView.as_view(), name='token_refresh'),
+]
+
+# doc urls
+urlpatterns += [
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/backend/eventsync_api/api/views/auth_view.py
+++ b/backend/eventsync_api/api/views/auth_view.py
@@ -1,4 +1,5 @@
 from core.models import ESUser
+from drf_spectacular.utils import extend_schema
 from rest_framework import generics
 from rest_framework.permissions import AllowAny
 

--- a/backend/eventsync_api/api/views/auth_view.py
+++ b/backend/eventsync_api/api/views/auth_view.py
@@ -1,8 +1,15 @@
+from core.models import ESUser
 from rest_framework import generics
 from rest_framework.permissions import AllowAny
-from core.models import ESUser
+
 from ..serializers.auth_serializers import RegisterSerializer
 
+
+@extend_schema(
+    request=RegisterSerializer,
+    responses={201: RegisterSerializer},
+    description="Register a new user",
+)
 class RegisterView(generics.CreateAPIView):
     queryset = ESUser.objects.all()
     permission_classes = (AllowAny,)

--- a/backend/eventsync_api/api/views/root_view.py
+++ b/backend/eventsync_api/api/views/root_view.py
@@ -11,6 +11,9 @@ class ApiRootView(APIView):
             'register': reverse('register', request=request, format=format),
             'login-token': reverse('token_obtain_pair', request=request, format=format),
             'refresh-token': reverse('token_refresh', request=request, format=format),
+            'swagger-json': reverse('schema', request=request, format=format),
+            'swagger-ui': reverse('swagger-ui', request=request, format=format),
+            'redoc-ui': reverse('redoc', request=request, format=format),
             # adicione mais endpoints aqui
         }
         return Response(data)

--- a/backend/eventsync_api/eventsync_api/settings.py
+++ b/backend/eventsync_api/eventsync_api/settings.py
@@ -143,6 +143,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 SIMPLE_JWT = {

--- a/backend/eventsync_api/eventsync_api/settings.py
+++ b/backend/eventsync_api/eventsync_api/settings.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'api.apps.ApiConfig',
     'core.apps.CoreConfig',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -148,4 +149,12 @@ SIMPLE_JWT = {
     'REFRESH_TOKEN_LIFETIME': timedelta(days=15),
     'ACCESS_TOKEN_LIFETIME': timedelta(days=3),
     'ROTATE_REFRESH_TOKENS': True,
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'EventSync API',
+    'DESCRIPTION': 'API dedicada ao projeto nomeado EventSync da disciplina de Engenharia de Software II',
+    'VERSION': '0.0.1',
+    'SERVE_INCLUDE_SCHEMA': False,
+    # OTHER SETTINGS
 }

--- a/backend/eventsync_api/requirements.txt
+++ b/backend/eventsync_api/requirements.txt
@@ -7,3 +7,6 @@ python-decouple==3.8
 
 # dependencia de login
 djangorestframework-simplejwt==5.3.1
+
+# dependencia de documentacao
+drf-spectacular==0.27.2


### PR DESCRIPTION
O que feito: 

- Tres novos endpoints funcionando ( os 3 estao na lista de endpoints na base do projeto)
- Endpoint `/schema `que retorna um json com todos os endpoints, que pode ser importado no postman/insomnia
- Endpoint `/schema/swagger` que abre a interface do swagger
- Endpoint /`schema/redoc ` que abre a interface do redoc

PS: Usem o comando `python manage.py collectstatic` antes de testar para toda interface aparecer corretamente